### PR TITLE
Test if file is in a directory with tests.

### DIFF
--- a/cmd/crebain/main.go
+++ b/cmd/crebain/main.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/ricardomaraschini/crebain/fbuffer"
@@ -78,22 +76,14 @@ func test(dirs []string) {
 	}
 }
 
-// hasTestFile is a filter that returns true if either filePath points to a
-// go test file or points to a go file with correspondent go test file.
+// hasTestFile is a filter that returns true if filePath belongs to a directory
+// containing test files.
 func hasTestFile(filePath string) bool {
 	if filepath.Ext(filePath) != ".go" {
 		return false
 	}
 
-	if strings.HasSuffix(filePath, "_test.go") {
-		return true
-	}
-
-	ext := filepath.Ext(filePath)
-	testFilePath := fmt.Sprintf(
-		"%s_test.go",
-		filePath[0:len(filePath)-len(ext)],
-	)
-	_, err := os.Stat(testFilePath)
-	return err == nil
+	dir := path.Dir(filePath)
+	testFiles, _ := filepath.Glob(dir + "/*_test.go")
+	return len(testFiles) > 0
 }

--- a/cmd/crebain/main_test.go
+++ b/cmd/crebain/main_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestHasTestFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "hasTestFile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	t.Run(".txt", func(t *testing.T) {
+		f, err := ioutil.TempFile(dir, "myfavouritesingers.*.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(f.Name())
+		defer f.Close()
+
+		if got := hasTestFile(f.Name()); got != false {
+			t.Fatal("File is not a valid go file, but it's recognized as it is!")
+		}
+	})
+
+	t.Run("_test.go", func(t *testing.T) {
+		f, err := os.Create(dir + "/awesome_test.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(f.Name())
+		defer f.Close()
+
+		if got := hasTestFile(f.Name()); got != true {
+			t.Fatal("File not recognized as testable")
+		}
+	})
+
+	t.Run(".go", func(t *testing.T) {
+		dotGo, err := os.Create(dir + "/could_be_better.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(dotGo.Name())
+		defer dotGo.Close()
+
+		t.Run("no tests", func(t *testing.T) {
+			if got := hasTestFile(dotGo.Name()); got != false {
+				t.Fatal("File recognized as belonging to a directory with packages")
+			}
+		})
+		t.Run("test present", func(t *testing.T) {
+			tf, err := os.Create(dir + "/could_be_better_test.go")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(tf.Name())
+			defer tf.Close()
+
+			if got := hasTestFile(dotGo.Name()); got != true {
+				t.Fatal("File not recognized as testable")
+			}
+		})
+		t.Run("test present but different name", func(t *testing.T) {
+			tf, err := os.Create(dir + "/plot_twist_test.go")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(tf.Name())
+			defer tf.Close()
+
+			if got := hasTestFile(dotGo.Name()); got != true {
+				t.Fatal("File not recognized as testable")
+			}
+		})
+	})
+}


### PR DESCRIPTION
This PR is changing the behavior of `hasTestFile`. Previously check was performed only if the modified file had a respective `_test.go` (or if was a `_test.go` file itself).
But this leads to a problem: sometimes, for example, you may want to have only few types definition in a file, which will be tested in other files within the same package. Even if the file itself could miss any relative `_test.go` file, changing it could indeed affects tests.

Even if good practice would be to have a `_test.go` file per every go file, sometimes this is not achievable.

This PR is enabling tests also in the case the changed file belongs to a directory which contains tests, regardless of its name.

Tests are provided as well to cover proper scenarios.