### PR TITLE
Accepts more events on watcher.

### DIFF
--- a/cmd/crebain/main.go
+++ b/cmd/crebain/main.go
@@ -35,6 +35,7 @@ func main() {
 		log.Fatal("NewWatcher:", err)
 	}
 	defer watcher.Close()
+	watcher.Loop()
 	drainLoop(buf, time.Second)
 }
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -117,7 +117,6 @@ func (w *Watcher) processEvent(event fsnotify.Event) {
 	// Ignore events that are only chmod.
 	// Write, rename and remove are ok.
 	if event.Op == fsnotify.Chmod {
-		log.Println("Chmod:", event.Name)
 		return
 	}
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -48,8 +48,11 @@ func New(path string, exclude matcher, buf buffer) (*Watcher, error) {
 		return nil, err
 	}
 
-	go watcher.loop()
 	return watcher, nil
+}
+
+func (w *Watcher) Loop() {
+	go w.loop()
 }
 
 // Watcher monitors changes on the filesystem.
@@ -136,8 +139,10 @@ func (w *Watcher) processEvent(event fsnotify.Event) {
 		return
 	}
 
-	// we only care about write changes from this point on.
-	if event.Op&fsnotify.Write != fsnotify.Write {
+	// Ignore events that are only chmod.
+	// Write, rename and remove are acceptable.
+	if event.Op == fsnotify.Chmod {
+		log.Println("Chmod:", event.Name)
 		return
 	}
 

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -97,27 +97,6 @@ func (d *dummyBuffer) Push(path string) {
 }
 
 func TestProcessEvent(t *testing.T) {
-	watchable, err := ioutil.TempDir("", "processEvent")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(watchable)
-
-	buf := &dummyBuffer{}
-	matcher := &dummyMatcher{
-		func(_ string) bool { return false },
-	}
-
-	w, err := New(
-		watchable,
-		matcher,
-		buf,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer w.Watcher.Close()
-
 	tmpDir, err := ioutil.TempDir("", "processEvent")
 	if err != nil {
 		t.Fatal(err)
@@ -129,7 +108,22 @@ func TestProcessEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tmpFile.Close()
+
 	name := tmpFile.Name()
+	buf := &dummyBuffer{}
+	matcher := &dummyMatcher{
+		func(_ string) bool { return false },
+	}
+
+	w, err := New(
+		tmpDir,
+		matcher,
+		buf,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Watcher.Close()
 
 	t.Run("accepted", func(t *testing.T) {
 		ops := []fsnotify.Op{

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -4,6 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/fsnotify/fsnotify"
 )
 
 type dummyMatcher struct {
@@ -84,4 +86,125 @@ func TestIsPathExcluded(t *testing.T) {
 	if got := watcher.isPathExcluded(path); got != expected {
 		t.Fatal("Unexpected result:", got)
 	}
+}
+
+type dummyBuffer struct {
+	element string
+}
+
+func (d *dummyBuffer) Push(path string) {
+	d.element = path
+}
+
+func TestProcessEvent(t *testing.T) {
+	watchable, err := ioutil.TempDir("", "processEvent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(watchable)
+
+	buf := &dummyBuffer{}
+	matcher := &dummyMatcher{
+		func(_ string) bool { return false },
+	}
+
+	w, err := New(
+		watchable,
+		matcher,
+		buf,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Watcher.Close()
+
+	tmpDir, err := ioutil.TempDir("", "processEvent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpFile, err := os.Create(tmpDir + "/confusion.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpFile.Close()
+	name := tmpFile.Name()
+
+	t.Run("accepted", func(t *testing.T) {
+		ops := []fsnotify.Op{
+			fsnotify.Create,
+			fsnotify.Create | fsnotify.Write,
+			fsnotify.Write,
+			fsnotify.Rename | fsnotify.Write,
+			fsnotify.Rename,
+			fsnotify.Chmod | fsnotify.Write,
+		}
+		for _, op := range ops {
+			t.Run(op.String(), func(t *testing.T) {
+				buf.element = ""
+
+				e := fsnotify.Event{
+					Name: name,
+					Op:   op,
+				}
+
+				w.processEvent(e)
+				if buf.element != name {
+					t.Fatalf("Ignored %s event", op)
+				}
+			})
+		}
+	})
+
+	t.Run("ignored", func(t *testing.T) {
+		t.Run("chmod", func(t *testing.T) {
+			buf.element = ""
+
+			op := fsnotify.Chmod
+			e := fsnotify.Event{
+				Name: name,
+				Op:   op,
+			}
+
+			w.processEvent(e)
+			if buf.element == name {
+				t.Fatalf("Accepted %s event", op)
+			}
+		})
+		t.Run("dir", func(t *testing.T) {
+			buf.element = ""
+			newDir, err := ioutil.TempDir("", "processEvent2")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(newDir)
+
+			op := fsnotify.Create
+			e := fsnotify.Event{
+				Name: newDir,
+				Op:   op,
+			}
+
+			w.processEvent(e)
+			if buf.element == newDir {
+				t.Fatalf("Accepted dir %s", newDir)
+			}
+		})
+		t.Run("excluded", func(t *testing.T) {
+			buf.element = ""
+			matcher.match = func(_ string) bool { return true }
+
+			op := fsnotify.Create
+			e := fsnotify.Event{
+				Name: name,
+				Op:   op,
+			}
+
+			w.processEvent(e)
+			if buf.element == name {
+				t.Fatalf("Accepted %s excluded", name)
+			}
+		})
+	})
 }


### PR DESCRIPTION
This  PR makes the watcher ignoring only chmods events. Remove and Rename are then now accepted as well.
It also implements a fix that doesn't allow files that matches the exclusion rules to be added in the buffer.

Behaviour is proofed by the new test "TestProcessEvent".