### PR TITLE
Resolve relative path.

### DIFF
--- a/cmd/crebain/main.go
+++ b/cmd/crebain/main.go
@@ -35,6 +35,11 @@ func main() {
 	flag.Var(&exclude, "exclude", "regex rules for excluding paths from watching")
 	flag.Parse()
 
+	*path, err = filepath.Abs(*path)
+	if err != nil {
+		log.Fatal("Path:", err)
+	}
+
 	if err := os.Chdir(*path); err != nil {
 		log.Fatal("Chdir:", err)
 	}


### PR DESCRIPTION
Currently only absolute path are accepted in `-path` flag. This simple PR adds the conversion from relative paths to absolute, so that the former can be used as well.